### PR TITLE
Add format parameter to Pages API example

### DIFF
--- a/cheatsheet.md
+++ b/cheatsheet.md
@@ -829,6 +829,7 @@ fetch("https://core.helloretail.com/serve/pages/{key}", {
         "url":"{url to category page}",
         "layout":"true",
         "firstLoad":"true",
+	"format":'json',
         "products":{
             "start":0,
             "count":4000,


### PR DESCRIPTION
This is required for the REST API. Otherwise it will fetch HTML code and not JSON by default.  / Feedback from Mikkel, but he had no access. (Invite him!)